### PR TITLE
Force the body to be a string.

### DIFF
--- a/endpoints/interface/__init__.py
+++ b/endpoints/interface/__init__.py
@@ -179,7 +179,8 @@ class BaseServer(object):
         """
         body_args = []
         body_kwargs = {}
-        b = json.loads(body)
+        body_string = str(body, "utf-8")
+        b = json.loads(body_string)
         if isinstance(b, list):
             body_args = b
 


### PR DESCRIPTION
When running endpoints from within a docker container for some reason the body portion is being decoded as a bytes-like object `b''`. The same code running locally works fine. I added a string conversion explicitly to force the body to be a string. 

We may want to look into support for the `Content-Type` header's `charset` attribute so we are not explicitly attempting to convert a non utf-8 string to utf-8.  If that is desired I can put a little more effort into this PR to support that as well. I ran into this issue which prevented me from moving forward. Maybe you have a better approach.

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/wsgiref/handlers.py", line 137, in run
    self.result = application(self.environ, self.start_response)
  File "/usr/local/lib/python3.5/dist-packages/endpoints/interface/wsgi/__init__.py", line 30, in __call__
    return self.handle_http_response(environ, start_response)
  File "/usr/local/lib/python3.5/dist-packages/endpoints/interface/wsgi/__init__.py", line 33, in handle_http_response
    c = self.create_call(environ)
  File "/usr/local/lib/python3.5/dist-packages/endpoints/interface/__init__.py", line 239, in create_call
    req = request if request else self.create_request(raw_request, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/endpoints/interface/wsgi/__init__.py", line 77, in create_request
    self.create_request_body(r, raw_request, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/endpoints/interface/wsgi/__init__.py", line 98, in create_request_body
    body_args, body_kwargs = self.get_request_body_json(body, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/endpoints/interface/__init__.py", line 182, in get_request_body_json
    b = json.loads(body)
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```